### PR TITLE
FEAT: font-size 62.5% 설정 - #8

### DIFF
--- a/src/componenet/PhotoGallery/Comment/index.tsx
+++ b/src/componenet/PhotoGallery/Comment/index.tsx
@@ -1,10 +1,10 @@
 function Comment() {
   return (
     <p className="font-tvNEnjoystoriesL text-center whitespace-pre">
-      <p className="text-[25px] leading-[100%] tracking-[-0.25px]">
+      <p className="text-[2.5rem] leading-[100%] tracking-[-0.025rem]">
         {`그리고 앞으로 당신과 함께\n만들어갈 청춘, 2024-!`}
       </p>
-      <p className="text-[15px] leading-[100%] tracking-[-0.15px] ">
+      <p className="text-[1.5rem] leading-[100%] tracking-[-0.015rem] ">
         {`\nwith COMMENCE`}
       </p>
     </p>

--- a/src/componenet/PhotoGallery/ThisYear/index.tsx
+++ b/src/componenet/PhotoGallery/ThisYear/index.tsx
@@ -1,6 +1,6 @@
 function ThisYear() {
   return (
-    <p className="font-tvNEnjoystoriesB text-[40px] leading-[100%] tracking-[-0.4px]">
+    <p className="font-tvNEnjoystoriesB text-[4.0rem] leading-[100%] tracking-[-0.04rem]">
       COMMENCE's 2023
     </p>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -8,6 +8,7 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  font-size: 62.5%;
 }
 
 @font-face {


### PR DESCRIPTION
🚨 **Pull request 전에 확인해야 할 사항( [x] 체크해주세요 )** 

- [x]  커밋 또는 모든 커밋의 메시지 스타일이 convention과 일치하는지 확인해주세요.

- [x] PR작업에 대한 오른쪽의 라벨을 붙여주세요.

## 📌 개요
<!---- 변경 사항 및 관련 이슈에 대해  무엇을 왜 수정했는지 간단히 설명해주세요.-->
font-size를 62.5%로 설정했습니다.
앞으로 rem 단위를 쓸 때 pixel에 0.1을 곱하여 rem값을 바로 설정할 수 있게 하기 위함입니다. 
ex) 10px -> 1rem

<!-- 관련있는 #이슈 번호를 적어주세요. 
해당 pull request merge와 함께 이슈를 닫으려면 closed #이슈 번호를 적어주세요. -->
closed #8 
  
## ✨ 작업 내용
<!-- 작업한 기능 대한 설명을 적어주세요 -->
- root의 font-size를 62.5%로 설정하였습니다.

## 📸 스크린샷(선택)
<!-- 스크린샷 또는 gif를 첨부해주세요 -->
<img width="212" alt="image" src="https://github.com/choiseona/commence-project-frontend/assets/52223965/ade09e61-ea2e-40d0-9130-2f35210df725">


## 🔊 리뷰어에게(선택)
<!-- 리뷰어에게 전달할 말을 작성해주세요 -->
이야기 나눈 대로 메뉴, 헤더, 푸터 어긋나는 부분 수정해주시면 될 것 같습니다.
<img width="490" alt="image" src="https://github.com/choiseona/commence-project-frontend/assets/52223965/5605721a-75eb-4fb1-bc16-2b129d6bb53e">


## 📚 추가 사항(선택)
