### PR TITLE
FIX: Header,Footer em => %, px => rem 단위 변경

### DIFF
--- a/src/componenet/Common/DeveloperButton/index.tsx
+++ b/src/componenet/Common/DeveloperButton/index.tsx
@@ -1,7 +1,7 @@
 function DeveloperButton() {
   return (
-    <button className="absolute top-[30px] right-[10px] bg-black  flex justify-center items-center w-[11.9%] h-[10%] rounded-2xl">
-      <span className="text-white font-AppleSDGothicNeoL00 text-[10%] mt-[3px]">
+    <button className="absolute top-[3rem] right-[1rem] bg-black  flex justify-center items-center w-[12%] h-[10%] rounded-2xl">
+      <span className="text-white font-AppleSDGothicNeoL00 text-[10%] mt-[0.3rem]">
         제작자 →
       </span>
     </button>

--- a/src/componenet/Common/Footer/index.tsx
+++ b/src/componenet/Common/Footer/index.tsx
@@ -5,7 +5,7 @@ import DeveloperButton from "../DeveloperButton";
 
 function Footer() {
   return (
-    <div title="footer" className="pt-[18px] pb-[10px] relative">
+    <div title="footer" className="pt-[1.8rem] pb-[1rem] relative">
       <DeveloperButton />
       <FooterTitle />
       <FooterText />

--- a/src/componenet/Common/FooterLinks/index.tsx
+++ b/src/componenet/Common/FooterLinks/index.tsx
@@ -8,8 +8,8 @@ function FooterLinks() {
     window.open(url);
   };
   return (
-    <div className="flex flex-col space-y-[2px] pl-[37px] mt-[20px]">
-      <span className="font-AppleSDGothicNeoL00 text-[0.72em] text-[#6E6E6E]">
+    <div className="flex flex-col space-y-[0.2rem] pl-[3.7rem] mt-[2rem]">
+      <span className="font-AppleSDGothicNeoL00 text-[130%] text-[#6E6E6E]">
         COMMENCE SNS
       </span>
       <div
@@ -19,10 +19,10 @@ function FooterLinks() {
         <img
           src={youtubeSmallMarkPNG}
           alt="youtube-smallmark"
-          className="-ml-[3px]"
+          className="-ml-[0.3rem]"
           width={"5%"}
         />
-        <span className="font-AppleSDGothicNeoM00 text-[7px] -ml-[2px]">
+        <span className="font-AppleSDGothicNeoM00 text-[0.7rem] -ml-[0.2rem]">
           YOUTUBE
         </span>
       </div>
@@ -36,7 +36,7 @@ function FooterLinks() {
           width={"3.5%"}
           height={"4%"}
         />
-        <span className="font-AppleSDGothicNeoM00 text-[7px] ml-[2px]">
+        <span className="font-AppleSDGothicNeoM00 text-[0.7rem] ml-[0.2rem]">
           Instagram
         </span>
       </div>

--- a/src/componenet/Common/FooterText/index.tsx
+++ b/src/componenet/Common/FooterText/index.tsx
@@ -1,13 +1,13 @@
 function FooterText() {
   return (
-    <div className="flex flex-col pl-[37px] mt-[6px] space-y-[5px]">
-      <span className="font-AppleSDGothicNeoL00 text-[0.72em] text-[#6E6E6E]">
+    <div className="flex flex-col pl-[3.7rem] mt-[0.6rem] space-y-[0.5rem]">
+      <span className="font-AppleSDGothicNeoL00 text-[130%] text-[#6E6E6E]">
         ©2024 Copyright COMMENCE
       </span>
-      <span className="font-AppleSDGothicNeoL00 text-[0.72em] text-[#6E6E6E]">
+      <span className="font-AppleSDGothicNeoL00 text-[130%] text-[#6E6E6E]">
         인천 미추홀구 인하로 100(용현동) 나빌레관 205호
       </span>
-      <span className="font-AppleSDGothicNeoL00 text-[0.72em] text-[#6E6E6E]">
+      <span className="font-AppleSDGothicNeoL00 text-[130%] text-[#6E6E6E]">
         개인정보처리방침
       </span>
     </div>

--- a/src/componenet/Common/FooterTitle/index.tsx
+++ b/src/componenet/Common/FooterTitle/index.tsx
@@ -2,11 +2,11 @@ import commenceSmallMarkPNG from "@/assets/images/commence-smallmarkPNG.png";
 
 function FooterTitle() {
   return (
-    <div className="flex items-center pl-[21px]">
+    <div className="flex items-center pl-[2.1rem]">
       <img src={commenceSmallMarkPNG} alt="commence-smallmark" width={"17%"} />
       <div className="flex flex-col ml-[2px]">
-        <span className="font-tvNEnjoystoriesM text-[1.26em]">COMMENCE</span>
-        <span className="font-AppleSDGothicNeoL00 text-[0.6em] text-[#6E6E6E] -mt-[10px]">
+        <span className="font-tvNEnjoystoriesM text-[204%]">COMMENCE</span>
+        <span className="font-AppleSDGothicNeoL00 text-[60%] text-[#6E6E6E] -mt-[1rem]">
           est.1984
         </span>
       </div>

--- a/src/componenet/Common/FooterTitle/index.tsx
+++ b/src/componenet/Common/FooterTitle/index.tsx
@@ -4,7 +4,7 @@ function FooterTitle() {
   return (
     <div className="flex items-center pl-[2.1rem]">
       <img src={commenceSmallMarkPNG} alt="commence-smallmark" width={"17%"} />
-      <div className="flex flex-col ml-[2px]">
+      <div className="flex flex-col ml-[0.2rem]">
         <span className="font-tvNEnjoystoriesM text-[204%]">COMMENCE</span>
         <span className="font-AppleSDGothicNeoL00 text-[60%] text-[#6E6E6E] -mt-[1rem]">
           est.1984

--- a/src/componenet/Common/Header/index.tsx
+++ b/src/componenet/Common/Header/index.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from "react-router-dom";
 
 function Header() {
   const [onMenuToggle, setOnMenuToggle] = useState(false);
+  const [onAboutus, setOnAboutus] = useState(false);
   const navigate = useNavigate();
 
   const onClickMenu = () => {
@@ -14,6 +15,7 @@ function Header() {
   const onClickHeader = () => {
     navigate("/");
     setOnMenuToggle(false);
+    setOnAboutus(false);
   }
   return (
     <>
@@ -25,7 +27,7 @@ function Header() {
           </span>
         </div>
       </nav>
-      <Menu onMenuToggle={onMenuToggle} setOnMenuToggle={setOnMenuToggle}/>
+      <Menu onMenuToggle={onMenuToggle} setOnMenuToggle={setOnMenuToggle} onAboutus={onAboutus} setOnAboutus={setOnAboutus}/>
     </>
   );
 };

--- a/src/componenet/Common/Header/index.tsx
+++ b/src/componenet/Common/Header/index.tsx
@@ -21,7 +21,7 @@ function Header() {
     <>
       <nav className="fixed top-0 max-w-[51.2rem] w-full bg-white h-[6rem] z-10">
         <div className="h-full w-full flex justify-center items-center relative">
-          <span className="text-[3.1em] font-Pretendard" onClick={onClickHeader}>COMMENCE</span>
+          <span className="text-[310%] font-Pretendard" onClick={onClickHeader}>COMMENCE</span>
           <span className="absolute right-[3rem] cursor-pointer">
             <img src={menuIcon} alt="menu-icon" onClick={onClickMenu}  />
           </span>

--- a/src/componenet/Common/Header/index.tsx
+++ b/src/componenet/Common/Header/index.tsx
@@ -10,10 +10,10 @@ function Header() {
   }
   return (
     <>
-      <nav className="fixed top-0 max-w-lg w-full bg-white h-[60px] z-10">
+      <nav className="fixed top-0 max-w-[51.2rem] w-full bg-white h-[6rem] z-10">
         <div className="h-full w-full flex justify-center items-center relative">
-          <span className="text-[1.94em] font-Pretendard">COMMENCE</span>
-          <span className="absolute right-[30px]">
+          <span className="text-[3.1em] font-Pretendard">COMMENCE</span>
+          <span className="absolute right-[3rem]">
             <img src={menuIcon} alt="menu-icon" onClick={onClick}  />
           </span>
         </div>

--- a/src/componenet/Common/Header/index.tsx
+++ b/src/componenet/Common/Header/index.tsx
@@ -1,20 +1,27 @@
 import menuIcon from "@/assets/icons/menu-icon.svg";
 import Menu from "../Menu";
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 
 function Header() {
   const [onMenuToggle, setOnMenuToggle] = useState(false);
-  const onClick = () => {
+  const navigate = useNavigate();
+
+  const onClickMenu = () => {
     setOnMenuToggle(prev => !prev)
+  }
+  const onClickHeader = () => {
+    navigate("/");
+    setOnMenuToggle(false);
   }
   return (
     <>
       <nav className="fixed top-0 max-w-[51.2rem] w-full bg-white h-[6rem] z-10">
         <div className="h-full w-full flex justify-center items-center relative">
-          <span className="text-[3.1em] font-Pretendard">COMMENCE</span>
-          <span className="absolute right-[3rem]">
-            <img src={menuIcon} alt="menu-icon" onClick={onClick}  />
+          <span className="text-[3.1em] font-Pretendard" onClick={onClickHeader}>COMMENCE</span>
+          <span className="absolute right-[3rem] cursor-pointer">
+            <img src={menuIcon} alt="menu-icon" onClick={onClickMenu}  />
           </span>
         </div>
       </nav>

--- a/src/componenet/Common/Layout/index.tsx
+++ b/src/componenet/Common/Layout/index.tsx
@@ -5,7 +5,7 @@ import Footer from "../Footer";
 function Layout() {
   
   return (
-    <div className="mt-[60px]">
+    <div className="mt-[6rem]">
       <Header/>
       <Outlet />
       <Footer/>

--- a/src/componenet/Common/Menu/index.tsx
+++ b/src/componenet/Common/Menu/index.tsx
@@ -39,7 +39,7 @@ function Menu({ onMenuToggle, setOnMenuToggle,onAboutus, setOnAboutus }: IParam)
         )}
       >
         <div className="flex justify-center align-middle py-[45px]">
-          <span className="font-AppleSDGothicNeoL00 text-[2.475em]">
+          <span className="font-AppleSDGothicNeoL00 text-[247.5%]">
             Welcome to{" "}
             <span className="font-AppleSDGothicNeoH00">COMMENCE</span>
           </span>

--- a/src/componenet/Common/Menu/index.tsx
+++ b/src/componenet/Common/Menu/index.tsx
@@ -1,26 +1,26 @@
 import DownArrow from "@/assets/icons/category-DownArrow.svg";
 import UpArrow from "@/assets/icons/category-UpArrow.svg";
 import { cls } from "@/libs/util";
-import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 
 interface IParam {
   onMenuToggle: boolean;
   setOnMenuToggle: React.Dispatch<React.SetStateAction<boolean>>;
+  onAboutus:boolean;
+  setOnAboutus:React.Dispatch<React.SetStateAction<boolean>>
 }
 
-function Menu({ onMenuToggle, setOnMenuToggle }: IParam) {
-  const [onAboutus, setAboutus] = useState(false);
+function Menu({ onMenuToggle, setOnMenuToggle,onAboutus, setOnAboutus }: IParam) {
   const navigate = useNavigate();
 
   const onClickAboutus = () => {
-    setAboutus((prev) => !prev);
+    setOnAboutus((prev) => !prev);
   };
   const onNavigate = (url: string) => {
     navigate(url);
     setOnMenuToggle(false);
-    setAboutus(false);
+    setOnAboutus(false);
   };
   return (
     <div

--- a/src/componenet/Common/Menu/index.tsx
+++ b/src/componenet/Common/Menu/index.tsx
@@ -19,8 +19,8 @@ function Menu({ onMenuToggle, setOnMenuToggle }: IParam) {
   };
   const onNavigate = (url: string) => {
     navigate(url);
-    setOnMenuToggle((prev) => !prev);
-    onClickAboutus();
+    setOnMenuToggle(false);
+    setAboutus(false);
   };
   return (
     <div

--- a/src/componenet/Common/Menu/index.tsx
+++ b/src/componenet/Common/Menu/index.tsx
@@ -25,7 +25,7 @@ function Menu({ onMenuToggle, setOnMenuToggle }: IParam) {
   return (
     <div
       className={cls(
-        "fixed top-2 max-w-lg w-full h-full z-[5]",
+        "fixed top-2 max-w-[51.2rem] w-full h-full z-[5]",
         onMenuToggle ? "" : "invisible"
       )}
     >
@@ -34,27 +34,27 @@ function Menu({ onMenuToggle, setOnMenuToggle }: IParam) {
         onMenuToggle ? "opacity-100" : "opacity-0")}
       ></div>
       <div
-        className={cls("absolute top-[48px] right-0 w-[80%] h-fit rounded-bl-[30px] shadow-[0_4px_4px_0px_rgba(0,0,0,0.25)] pb-[30%] bg-white z-[5] duration-300 ease-out transition-all",
+        className={cls("absolute top-[4.8rem] right-0 w-[80%] h-fit rounded-bl-[30px] shadow-[0_4px_4px_0px_rgba(0,0,0,0.25)] pb-[30%] bg-white z-[5] duration-300 ease-out transition-all",
         onMenuToggle ? "opacity-100" : "opacity-0 translate-x-full"
         )}
       >
         <div className="flex justify-center align-middle py-[45px]">
-          <span className="font-AppleSDGothicNeoL00 text-[1.225em]">
+          <span className="font-AppleSDGothicNeoL00 text-[2.475em]">
             Welcome to{" "}
-            <span className="font-AppleSDGothicNeoH00">COMMANCE</span>
+            <span className="font-AppleSDGothicNeoH00">COMMENCE</span>
           </span>
         </div>
         <div className="pl-[10.1%]">
-          <div className="font-AppleSDGothicNeoH00 text-[30px] mb-[45px]">
+          <div className="font-AppleSDGothicNeoH00 text-[3rem] mb-[4.5rem]">
             Menu
           </div>
-          <ul className="space-y-[30px]">
+          <ul className="space-y-[3rem]">
             <li>
               <div
                 onClick={onClickAboutus}
                 className="flex justify-between cursor-pointer"
               >
-                <span className="font-AppleSDGothicNeoL00 text-[23px] ">
+                <span className="font-AppleSDGothicNeoL00 text-[2.3rem] ">
                   About us
                 </span>
                 <img
@@ -63,15 +63,15 @@ function Menu({ onMenuToggle, setOnMenuToggle }: IParam) {
                 />
               </div>
               {onAboutus && (
-                <ul id="about_us-container" className="mt-[15px]">
+                <ul id="about_us-container" className="mt-[1.5rem]">
                   <li
-                    className="font-AppleSDGothicNeoM00 text-[14px] text-[#6E6E6E] cursor-pointer"
+                    className="font-AppleSDGothicNeoM00 text-[1.4rem] text-[#6E6E6E] cursor-pointer"
                     onClick={() => onNavigate("/about-us")}
                   >
                     -꼬망스의 40년
                   </li>
                   <li
-                    className="font-AppleSDGothicNeoM00 text-[14px] text-[#6E6E6E] cursor-pointer"
+                    className="font-AppleSDGothicNeoM00 text-[1.4rem] text-[#6E6E6E] cursor-pointer"
                     onClick={() => onNavigate("/photo")}
                   >
                     -꼬망스의 1년
@@ -80,19 +80,19 @@ function Menu({ onMenuToggle, setOnMenuToggle }: IParam) {
               )}
             </li>
             <li
-              className="font-AppleSDGothicNeoL00 text-[23px] cursor-pointer"
+              className="font-AppleSDGothicNeoL00 text-[2.3rem] cursor-pointer"
               onClick={() => onNavigate("/performance-video")}
             >
               Performance
             </li>
             <li
-              className="font-AppleSDGothicNeoL00 text-[23px] cursor-pointer"
+              className="font-AppleSDGothicNeoL00 text-[2.3rem] cursor-pointer"
               onClick={() => onNavigate("/how-to-join")}
             >
               How to join
             </li>
             <li
-              className="font-AppleSDGothicNeoL00 text-[23px] cursor-pointer"
+              className="font-AppleSDGothicNeoL00 text-[2.3rem] cursor-pointer"
               onClick={() => onNavigate("/faq")}
             >
               FAQ


### PR DESCRIPTION
🚨 **Pull request 전에 확인해야 할 사항( [x] 체크해주세요 )** 

- [x]  **반드시 확인할 것!** <br> pull a topic/feature/bugfix branch 에서 dev branch로 PR요청하는지 확인하세요.<br> **master/main에 하시면 안됩니다.**

- [x]  커밋 또는 모든 커밋의 메시지 스타일이 convention과 일치하는지 확인해주세요.

- [x] PR작업에 대한 오른쪽의 라벨을 붙여주세요.

## 📌 개요
<!---- 변경 사항 및 관련 이슈에 대해  무엇을 왜 수정했는지 간단히 설명해주세요.-->
root의 style의 변경으로 기존 코드의 단위 수정을 했습니다.
또한 Header의 title을 누르면 home으로 가도록 기능을 추가 했습니다.
<!-- 관련있는 #이슈 번호를 적어주세요. 
해당 pull request merge와 함께 이슈를 닫으려면 closed #이슈 번호를 적어주세요. -->
closed #15 
## ✨ 작업 내용
<!-- 작업한 기능 대한 설명을 적어주세요 -->
Header와 Footer의 em => %, px => rem으로 변
## 📸 스크린샷(선택)
<!-- 스크린샷 또는 gif를 첨부해주세요 -->

## 🔊 리뷰어에게(선택)
<!-- 리뷰어에게 전달할 말을 작성해주세요 -->

## 📚 추가 사항(선택)
![image](https://github.com/choiseona/commence-project-frontend/assets/93645009/a104d790-a303-475e-b270-91e7203a6659)
Header에 COMMENCE에 홈으로 가는 redirect기능을 작업 하는 도중 금기를 범했습니다. Header 컴포넌트와 Menu 컴포넌트가 분리되어 있어서 저렇게 하지 않으면 About us 카테고리가 열려있는 상태로 Home으로 이동하게 되는 경우가 발생해서 어쩔 수 없이 저렇게 코드를 짰습니다.